### PR TITLE
Fix frozen string error

### DIFF
--- a/lib/rasn1/types/bit_string.rb
+++ b/lib/rasn1/types/bit_string.rb
@@ -70,9 +70,8 @@ module RASN1
       end
 
       def generate_value_with_correct_length
-        value = @value || ''
-        value << "\x00" while value.length * 8 < @bit_length.to_i
-        value.force_encoding('BINARY')
+        value = (@value || '').dup.force_encoding('BINARY')
+        value << "\x00".b while value.length * 8 < @bit_length.to_i
         return value unless value.length * 8 > @bit_length.to_i
 
         max_len = @bit_length.to_i / 8 + ((@bit_length.to_i % 8).positive? ? 1 : 0)

--- a/spec/types/bit_string_spec.rb
+++ b/spec/types/bit_string_spec.rb
@@ -37,6 +37,13 @@ module RASN1::Types
         expect(bs.to_der).to eq(binary("\x03\x04\x04NOP"))
       end
 
+      it 'generates a DER string with frozen strings' do
+        bs = BitString.new
+        bs.value = 'NOP'.freeze
+        bs.bit_length = 20
+        expect(bs.to_der).to eq(binary("\x03\x04\x04NOP"))
+      end
+
       it 'adds zero bits if value size is lesser than bit length' do
         bs = BitString.new
         bs.value = 'abc'


### PR DESCRIPTION
Fixing an issue I ran into when using the library:
```
lib/rasn1/types/bit_string.rb:74:in `generate_value_with_correct_length' FrozenError (can't modify frozen String: "")
```

~~Fix similar to: https://github.com/sdaubert/rasn1/commit/8e38eb0b3035f0692734fd11ac693f1d0d5ba149#diff-635059cb5d4331badab0036d39b0f7d643f31dd1655c2c113c948dba5529e2d7R435~~

~~I planned to add tests for this scenario - but I hit this issue a while ago and I unfortunately wasn't able to replicate again - other than having the error log saved. Revisiting the code path it looks like there's a lot of logic to force `@value` to be assigned the void_value of an empty string, but the crash definitely happened~~

Edit: Tests added and using a different approach now; I wasn't able to replicate originally as the test file didn't have the frozen string magic comment, I've explicitly frozen the input test string now.