### PR TITLE
Track source location correctly for dynamic class methods

### DIFF
--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -106,27 +106,27 @@ module RASN1
       end
 
       def define_type_accel_base(accel_name, klass)
-        singleton_class.class_eval(
-          "def #{accel_name}(name, options={})\n" \
-          "  options[:name] = name\n" \
-          "  proc = proc do |opts|\n" \
-          "    #{klass}.new(options.merge(opts))\n" \
-          "  end\n" \
-          "  @root = Elem.new(name, proc, options[:content])\n" \
-          'end'
-        )
+        singleton_class.class_eval <<-EVAL, __FILE__, __LINE__ + 1
+          def #{accel_name}(name, options={}) # def sequence(name, type, options)
+            options[:name] = name
+            proc = proc do |opts|
+              #{klass}.new(options.merge(opts)) # Sequence.new(options.merge(opts))
+            end
+            @root = Elem.new(name, proc, options[:content])
+          end
+        EVAL
       end
 
       def define_type_accel_of(accel_name, klass)
-        singleton_class.class_eval(
-          "def #{accel_name}_of(name, type, options={})\n" \
-          "  options[:name] = name\n" \
-          "  proc = proc do |opts|\n" \
-          "    #{klass}.new(type, options.merge(opts))\n" \
-          "  end\n" \
-          "  @root = Elem.new(name, proc, nil)\n" \
-          'end'
-        )
+        singleton_class.class_eval <<-EVAL, __FILE__, __LINE__ + 1
+          def #{accel_name}_of(name, type, options={}) # def sequence_of(name, type, options)
+            options[:name] = name
+            proc = proc do |opts|
+              #{klass}.new(type, options.merge(opts)) # SequenceOf.new(type, options.merge(opts))
+            end
+            @root = Elem.new(name, proc, nil)
+          end
+        EVAL
       end
 
       # Define an accelarator to access a type in a model definition

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -71,6 +71,26 @@ module RASN1
       end
     end
 
+    [
+      :sequence,
+      :sequence_of,
+      :set,
+      :set_of,
+      :choice,
+    ].each do |method_name|
+      describe ".#{method_name}" do
+        it 'has a line number and source location associated with the rasn1 namespace' do
+          method = described_class.method(method_name)
+          method_source_file, method_source_line = method.source_location
+
+          # By default this will be `["(eval)", 1]` if line/source are not passed to eval
+          # This verifies it is located within the rasn1 namespace
+          expect(method_source_file).to match /rasn1/
+          expect(method_source_line).to be_an_instance_of(Integer)
+        end
+      end
+    end
+
     describe '#initialize' do
       it 'creates a class from a Model' do
         expect { ModelTest.new }.to_not raise_error


### PR DESCRIPTION
Before:

```ruby
bundle exec irb             
2.7.2 :001 > require 'rasn1'
 => true 
2.7.2 :002 > RASN1::Model.method(:sequence).source_location
 => ["(eval)", 1]
```

After:

```ruby
bundle exec irb
2.7.2 :001 > require 'rasn1'
 => true 
2.7.2 :002 > RASN1::Model.method(:sequence).source_location
 => ["/Users/user/Documents/code/rasn1/lib/rasn1/model.rb", 110] 
```