### PR TITLE
Add validation for unique names

### DIFF
--- a/lib/rasn1/errors.rb
+++ b/lib/rasn1/errors.rb
@@ -40,4 +40,8 @@ module RASN1
       "Constraint not verified on #{@object.inspect}"
     end
   end
+
+  # Exception raised when model validation fails
+  class ModelValidationError < Error
+  end
 end

--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -64,7 +64,26 @@ module RASN1
   # @author Sylvain Daubert
   class Model
     # @private
-    Elem = Struct.new(:name, :proc_or_class, :content)
+    Elem = Struct.new(:name, :proc_or_class, :content) do
+      def initialize(name, proc_or_class, content)
+        if content
+          duplicate_names = find_all_duplicate_names(content.map(&:name) + [name])
+          raise ModelValidationError, "Duplicate name #{duplicate_names.first} found" if duplicate_names.any?
+        end
+
+        super
+      end
+
+      private
+
+      # @param [Array<String>] names
+      # @return [Array<String>] The duplicate names found in the array
+      def find_all_duplicate_names(names)
+        names.group_by { |name| name }
+             .select { |_name, values| values.length > 1 }
+             .keys
+      end
+    end
 
     # @private
     module Accel

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -113,6 +113,30 @@ module RASN1
         expect(model[:of][:seqof][1][:room].value).to eq(43)
         expect(model[:of][:seqof][1][:house].to_i).to eq(21)
       end
+
+      context 'when there are duplicate names present in the model' do
+        it 'raises an exception when the sequence name is the same as the content name' do
+          expect do
+            Class.new(described_class) do
+              sequence :foo,
+                       content: [integer(:foo),
+                                 integer(:bar)]
+            end
+          end.to raise_error(ModelValidationError).with_message('Duplicate name foo found')
+        end
+
+        it 'raises an exception when the content has duplicate names' do
+          expect do
+            Class.new(described_class) do
+              sequence :model,
+                       content: [integer(:foo),
+                                 objectid(:bar),
+                                 integer(:baz),
+                                 bit_string(:bar)]
+            end
+          end.to raise_error(ModelValidationError).with_message('Duplicate name bar found')
+        end
+      end
     end
 
     describe '#name' do


### PR DESCRIPTION
Adds validation for unique names - closes https://github.com/sdaubert/rasn1/issues/12

I think in the future it'd be cool to add support for this type of model to be implemented without an error:

```asn1
   Checksum        ::= SEQUENCE {
           cksumtype       [0] Int32,
           checksum        [1] OCTET STRING
   }
```

```ruby
require 'rasn1'

checksum_input = (
  "\x30\x19\xa0\x03\x02\x01\x07\xa1\x12\x04\x10\x9e\xf0\x84\xd6\x81" \
  "\xe5\x16\x02\x32\xb1\xc3\x4e\xad\x83\x1d\x43"
).b

class CheckSum < RASN1::Model
  sequence :checksum,
           content: [
             integer(:cksumtype, explicit: 0, constructed: true),
             octet_string(:checksum, explicit: 1, constructed: true)
           ]
end

pp CheckSum.parse(checksum_input)
```

But I think this improves the UX for now either way 💯

### Before

Unclear exception during initialisation:

```
$ bundle exec ruby foo.rb     
Traceback (most recent call last):
        5: from foo.rb:17:in `<main>'
        4: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:180:in `parse'
        3: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:350:in `parse!'
        2: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:215:in `parse!'
        1: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:442:in `check_id'
/Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:484:in `raise_id_error': checksum: Expected CONTEXT CONSTRUCTED 0x1 (0xa1) but get UNIVERSAL CONSTRUCTED SEQUENCE (RASN1::ASN1Error)
```

### After

A validation exception is now raised during initialization:

```
Traceback (most recent call last):
        10: from foo.rb:17:in `<main>'
         9: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:179:in `parse'
         8: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:179:in `new'
         7: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:287:in `initialize'
         6: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:459:in `generate_root'
         5: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:449:in `get_type'
         4: from (eval):4:in `block in sequence'
         3: from (eval):4:in `new'
         2: from /Users/user/Documents/code/rasn1/lib/rasn1/types/sequence.rb:34:in `initialize'
         1: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:119:in `initialize'
/Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:308:in `set_options': Duplicate name checksum found (RASN1::ValidationError)
```

Potentially it makes sense to have this validation happen immediately on the class method `sequence_of` call instead at initilaization time - but I wasn't sure if that would handle all the edgecases correctly