### PR TITLE
Fix name calculation for wrapper elements

### DIFF
--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -588,6 +588,8 @@ module RASN1
         name = case el
                when Model
                  @elements.key(el)
+               when Wrapper
+                 @elements.key(el.element)
                else
                  el.name
                end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -216,14 +216,14 @@ module RASN1 # rubocop:disable Metrics/moduleLength
         model = ModelWithImplicitWrapper.new
         model[:a_record][:id] = 2
         model[:a_record][:house] = 3
-        expect(model.to_h).to eq({ seq: { record: { id: 2, house: 3 } } })
+        expect(model.to_h).to eq({ seq: { a_record: { id: 2, house: 3 } } })
       end
 
       it 'generates a Hash image of a model with an explicit wrapped submodel' do
         model = ModelWithExplicitWrapper.new
         model[:a_record][:id] = 4
         model[:a_record][:house] = 5
-        expect(model.to_h).to eq({ seq: { record: { id: 4, house: 5 } } })
+        expect(model.to_h).to eq({ seq: { a_record: { id: 4, house: 5 } } })
       end
     end
 


### PR DESCRIPTION
I was hitting this issue with the recent changes; The wrapper model's real name in the sequence wasn't being used - instead the original model's name was being used.