### PR TITLE
Fix to der crash for optional wrapped constructed submodel

### DIFF
--- a/lib/rasn1/types/constructed.rb
+++ b/lib/rasn1/types/constructed.rb
@@ -19,7 +19,11 @@ module RASN1
           return super unless optional?
           return false unless super
 
-          @value.any? { |el| el.can_build? && (el.primitive? || !el.value.empty?) }
+          @value.any? do |el|
+            el.can_build? && (
+              el.primitive? ||
+                (el.value.respond_to?(:empty?) ? !el.value.empty? : !el.value.nil?))
+          end
         else
           super
         end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -57,6 +57,11 @@ module RASN1Test
     sequence :s, content: [integer(:superid),
                            wrapper(model(:submodel, TestModel::ModelTest), optional: true, explicit: 5)]
   end
+
+  class OptionalWrappedConstructedSubModel < RASN1::Model
+    sequence :s, content: [integer(:superid),
+                           wrapper(model(:submodel, TestModel::ConstructedModelTest), optional: true, explicit: 5)]
+  end
 end
 
 # rubocop:disable Metrics/BlockLength
@@ -74,6 +79,7 @@ module RASN1 # rubocop:disable Metrics/moduleLength
   EXPLICIT_WRAPPED_SUBMODEL = "\x30\x0c\x86\x0a\xa4\x08\x02\x01\x0a\x81\x03\x02\x01\x33".b.freeze
   OPTIONAL_VOID_WRAPPED_SUBMODEL = "\x30\x03\x02\x01\x01".b.freeze
   OPTIONAL_PLAIN_WRAPPED_SUBMODEL = "\x30\x0f\x02\x01\x01\x85\x0a\x30\x08\x02\x01\x0a\x81\x03\x02\x01\x33".b.freeze
+  OPTIONAL_CONSTRUCTED_WRAPPED_SUBMODEL = "\x30\x0f\x02\x01\x01\x85\x0a\x30\x08\x22\x01\x0a\xa1\x03\x02\x01\x33".b.freeze
 
   describe Model do
     describe '.root_options' do
@@ -127,6 +133,14 @@ module RASN1 # rubocop:disable Metrics/moduleLength
 
         model = RASN1Test::OptionalWrappedSubModel.new(superid: 1, submodel: { id: 10, house: 51 })
         expect(model.to_der).to eq(OPTIONAL_PLAIN_WRAPPED_SUBMODEL)
+      end
+
+      it 'optionally wraps a submodel with a constructed value' do
+        model = RASN1Test::OptionalWrappedConstructedSubModel.new(superid: 1)
+        expect(model.to_der).to eq(OPTIONAL_VOID_WRAPPED_SUBMODEL)
+
+        model = RASN1Test::OptionalWrappedConstructedSubModel.new(superid: 1, submodel: { id: 10, house: 51 })
+        expect(model.to_der).to eq(OPTIONAL_CONSTRUCTED_WRAPPED_SUBMODEL)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,13 @@ module TestModel
                        integer(:house, explicit: 1, default: 0)]
   end
 
+  class ConstructedModelTest < RASN1::Model
+    sequence :record,
+             content: [integer(:id, constructed: true),
+                       integer(:room, implicit: 0, constructed: true, optional: true),
+                       integer(:house, explicit: 1, constructed: true, default: 0)]
+  end
+
   class ModelTest2 < RASN1::Model
     sequence :record2,
              content: [boolean(:rented),


### PR DESCRIPTION
After rebasing the kerberos specs in https://github.com/sdaubert/rasn1/pull/17, I hit the following error:

```
  7) Kerberos Kerberos::EncKrbCredPart#parse parses the data successfully
     Failure/Error: @value.any? { |el| el.can_build? && (el.primitive? || !el.value.empty?) }
     
     NoMethodError:
       undefined method `empty?' for 1:Integer
     # ./lib/rasn1/types/constructed.rb:22:in `block in can_build?'
     # ./lib/rasn1/types/constructed.rb:22:in `any?'
     # ./lib/rasn1/types/constructed.rb:22:in `can_build?'
     # ./lib/rasn1/types/base.rb:379:in `build'
     # ./lib/rasn1/types/base.rb:185:in `to_der'
     # ./lib/rasn1/model.rb:370:in `to_der'
     # ./lib/rasn1/model.rb:450:in `=='
     # ./lib/rasn1/model.rb:594:in `key'
     # ./lib/rasn1/model.rb:594:in `block in sequence_to_h'
     # ./lib/rasn1/model.rb:585:in `map'
     # ./lib/rasn1/model.rb:585:in `sequence_to_h'
     # ./lib/rasn1/model.rb:563:in `private_to_h'
     # ./lib/rasn1/model.rb:359:in `to_h'
     # ./lib/rasn1/model.rb:578:in `block in sequence_of_to_h'
     # ./lib/rasn1/model.rb:578:in `map'
     # ./lib/rasn1/model.rb:578:in `sequence_of_to_h'
     # ./lib/rasn1/model.rb:561:in `private_to_h'
     # ./lib/rasn1/model.rb:596:in `block in sequence_to_h'
     # ./lib/rasn1/model.rb:585:in `map'
     # ./lib/rasn1/model.rb:585:in `sequence_to_h'
     # ./lib/rasn1/model.rb:563:in `private_to_h'
     # ./lib/rasn1/model.rb:359:in `to_h'
     # ./spec/kerberos_spec.rb:2176:in `block (4 levels) in <top (required)>'
```

Minimal test case:

```ruby
require 'rasn1'

class Checksum < RASN1::Model
  sequence :checksum,
           content: [
             integer(:checksum_type, constructed: true),
           ]
end

class Authenticator < RASN1::Model
  sequence :authenticator,
           content: [
             wrapper(model(:checksum, Checksum), optional: true),
           ]
end

data = {
  checksum: {
    checksum_type: 7,
  }
}

model = Authenticator.new(data).to_der
```

Failure:
```
Traceback (most recent call last):
        12: from test_case.rb:23:in `<main>'
        11: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:370:in `to_der'
        10: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:185:in `to_der'
         9: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:385:in `build'
         8: from /Users/user/Documents/code/rasn1/lib/rasn1/types/sequence.rb:73:in `value_to_der'
         7: from /Users/user/Documents/code/rasn1/lib/rasn1/types/sequence.rb:73:in `map'
         6: from /Users/user/Documents/code/rasn1/lib/rasn1/wrapper.rb:101:in `to_der'
         5: from /Users/user/Documents/code/rasn1/lib/rasn1/model.rb:370:in `to_der'
         4: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:185:in `to_der'
         3: from /Users/user/Documents/code/rasn1/lib/rasn1/types/base.rb:379:in `build'
         2: from /Users/user/Documents/code/rasn1/lib/rasn1/types/constructed.rb:22:in `can_build?'
         1: from /Users/user/Documents/code/rasn1/lib/rasn1/types/constructed.rb:22:in `any?'
/Users/user/Documents/code/rasn1/lib/rasn1/types/constructed.rb:22:in `block in can_build?': undefined method `empty?' for 7:Integer (NoMethodError)
```