### PR TITLE
Fix to_der crash when using Time object with generalized time

### DIFF
--- a/lib/rasn1/types/generalized_time.rb
+++ b/lib/rasn1/types/generalized_time.rb
@@ -45,7 +45,8 @@ module RASN1
       private
 
       def value_to_der
-        utc_value = @value.new_offset('0')
+        value = @value.is_a?(DateTime) ? @value : @value.to_datetime
+        utc_value = value.new_offset('0')
         if utc_value.sec_fraction.positive?
           der = utc_value.strftime('%Y%m%d%H%M%S.%9NZ')
           der.sub(/0+Z/, 'Z')

--- a/spec/types/generalized_time_spec.rb
+++ b/spec/types/generalized_time_spec.rb
@@ -34,6 +34,12 @@ module RASN1::Types
         gt.value = DateTime.new(2017, 12, 30, 16, 30, 23.55, 0)
         expect(gt.to_der).to eq("\x18\x1220171230163023.55Z".b)
       end
+
+      it 'generates a DER string with a Time object' do
+        gt = GeneralizedTime.new
+        gt.value = Time.new(2017, 12, 30, 16, 30, 23.55, 0)
+        expect(gt.to_der).to eq("\x18\x1220171230163023.55Z".b)
+      end
     end
 
     describe '#parse!' do


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/sdaubert/rasn1/commit/cb6fa343576fb20d37553fa46ce7f2623d1160b4#diff-e46f1c104156737e7ff48431864f3d1133526c88f222309f2f16891ffab1ff69R48

```
  1) RASN1::Types::GeneralizedTime#to_der generates a DER string with a Time object
     Failure/Error: utc_value = @value.new_offset('0')
     
     NoMethodError:
       undefined method `new_offset' for 2017-12-30 16:30:23 154811237190861/281474976710656 +0000:Time
     # ./lib/rasn1/types/generalized_time.rb:48:in `value_to_der'
     # ./lib/rasn1/types/base.rb:385:in `build'
     # ./lib/rasn1/types/base.rb:185:in `to_der'
     # ./spec/types/generalized_time_spec.rb:41:in `block (3 levels) in <module:Types>'
```