### PR TITLE
Add model to_h support for choice elements

### DIFF
--- a/lib/rasn1/errors.rb
+++ b/lib/rasn1/errors.rb
@@ -20,8 +20,14 @@ module RASN1
 
   # CHOICE error: #chosen not set
   class ChoiceError < RASN1::Error
+    # @param [Types::Base] object
+    def initialize(object)
+      @object = object
+      super()
+    end
+
     def message
-      "CHOICE #{@name}: #chosen not set"
+      "CHOICE #{@object.name}: #chosen not set"
     end
   end
 

--- a/lib/rasn1/model.rb
+++ b/lib/rasn1/model.rb
@@ -561,6 +561,10 @@ module RASN1
                 sequence_of_to_h(my_element)
               when Types::Sequence
                 sequence_to_h(my_element)
+              when Types::Choice
+                raise ChoiceError.new(my_element) if my_element.chosen.nil?
+
+                private_to_h(my_element.value[my_element.chosen])
               when Wrapper
                 wrapper_to_h(my_element)
               else

--- a/lib/rasn1/types/choice.rb
+++ b/lib/rasn1/types/choice.rb
@@ -100,7 +100,7 @@ module RASN1
       private
 
       def check_chosen
-        raise ChoiceError if !defined?(@chosen) || @chosen.nil?
+        raise ChoiceError.new(self) if !defined?(@chosen) || @chosen.nil?
       end
     end
   end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -255,6 +255,18 @@ module RASN1 # rubocop:disable Metrics/moduleLength
                                            { id: 2, house: 1 }] })
       end
 
+      it 'generates a Hash image of a model with a choice model' do
+        model = ModelChoice.parse(CHOICE_INTEGER)
+        expect(model.to_h).to eq({ choice: 16 })
+
+        model = ModelChoice.parse(CHOICE_SEQUENCE)
+        expect(model.to_h).to eq({ choice: { id: 65537, room: 43, house: 4660 } })
+
+        model = ModelChoice.new
+        expect { model.to_h }
+          .to raise_error(an_instance_of(RASN1::ChoiceError).and having_attributes({"message" => "CHOICE choice: #chosen not set"}))
+      end
+
       it 'generates a Hash image of a model with an implicit wrapped submodel' do
         model = ModelWithImplicitWrapper.new
         model[:a_record][:id] = 2

--- a/spec/types/choice_spec.rb
+++ b/spec/types/choice_spec.rb
@@ -22,7 +22,7 @@ module RASN1::Types
 
     context '(chosen value)' do
       before(:each) do
-        @choice = Choice.new
+        @choice = Choice.new name: :mock_choice_name
         @choice.value = [Integer.new, OctetString.new]
       end
 
@@ -70,7 +70,8 @@ module RASN1::Types
         end
 
         it 'raises if chosen is not set' do
-          expect { @choice.to_der }.to raise_error(RASN1::ChoiceError)
+          expect { @choice.to_der }
+            .to raise_error(an_instance_of(RASN1::ChoiceError).and having_attributes({"message" => "CHOICE mock_choice_name: #chosen not set"}))
         end
       end
     end


### PR DESCRIPTION
Choice elements are not currently being output as a hash when calling `to_h` on the model

Example failure:
```ruby
model = ModelChoice.parse(CHOICE_INTEGER)
expect(model.to_h).to eq({ choice: 16 })
```

Before this code change, the following error was raised:

```
  1) RASN1::Model#to_h generates a Hash image of a model with a choice model
     Failure/Error: expect(model.to_h).to eq({ choice: 16 })
     
       expected: {:choice=>16}
            got: {:choice=>[id INTEGER: 16, (ModelTest) record SEQUENCE:
         id INTEGER: (NO VALUE)
         room CONTEXT [0] IMPLICIT INTEGER: (NO VALUE) OPTIONAL
         house CONTEXT [1] EXPLICIT INTEGER: (NO VALUE) DEFAULT 0
       ]}
     
       (compared using ==)
```
