### PR TITLE
Allow CHOICE instances to be optional

### DIFF
--- a/lib/rasn1/types/choice.rb
+++ b/lib/rasn1/types/choice.rb
@@ -79,9 +79,7 @@ module RASN1
           @chosen = i
           nb_bytes = element.parse!(der, ber: ber)
           return nb_bytes
-        rescue ASN1Error => e
-          #$stderr.puts e.inspect
-          #$stderr.puts e.backtrace
+        rescue ASN1Error
           @chosen = nil
           next
         end

--- a/lib/rasn1/types/choice.rb
+++ b/lib/rasn1/types/choice.rb
@@ -75,24 +75,29 @@ module RASN1
       # @return [Integer] total number of parsed bytes
       # @raise [ASN1Error] error on parsing
       def parse!(der, ber: false)
-        parsed = false
         @value.each_with_index do |element, i|
           @chosen = i
           nb_bytes = element.parse!(der, ber: ber)
-          parsed = true
           return nb_bytes
-        rescue ASN1Error
+        rescue ASN1Error => e
+          #$stderr.puts e.inspect
+          #$stderr.puts e.backtrace
           @chosen = nil
           next
         end
-        raise ASN1Error, "CHOICE #{@name}: no type matching #{der.inspect}" unless parsed
+
+        @no_value = true
+        @value = void_value
+        raise ASN1Error, "CHOICE #{@name}: no type matching #{der.inspect}" unless optional?
+
+        0
       end
 
       # @param [::Integer] level
       # @return [String]
       def inspect(level=0)
         str = common_inspect(level)
-        str << if defined? @chosen
+        str << if defined?(@chosen) && value?
                  "\n#{@value[@chosen].inspect(level + 1)}"
                else
                  ' not chosen!'

--- a/spec/types/choice_spec.rb
+++ b/spec/types/choice_spec.rb
@@ -94,9 +94,17 @@ module RASN1::Types
         expect(nb_bytes).to eq(4)
       end
 
-      it 'raises when parsin a DER string which does not contain any type from CHOICE' do
-        str = Boolean.new(value: false).to_der
-        expect { @choice.parse! str }.to raise_error(RASN1::ASN1Error, /no type matching/)
+      context 'when parsing a DER string which does not contain any type from CHOICE' do
+        it 'raises RASN1::ASN1Error' do
+          str = Boolean.new(value: false).to_der
+          expect { @choice.parse! str }.to raise_error(RASN1::ASN1Error, /no type matching/)
+        end
+
+        it 'does not raise RASN1::ASN1Error when optional' do
+          str = Boolean.new(value: false).to_der
+          @choice.options = @choice.options.merge optional: true
+          expect { @choice.parse! str }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
This fixes a problem when parsing CHOICE instances that are optional. Because none of the values will parse correctly, an exception will always be raised when I'm pretty sure this should not be the case when the type is optional.

I noticed this while writing up a definition for # https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.7. Specifically the `BuiltInStandardAttributes` `PrivateDomainName` subfield was causing this problem when it wasn't defined.

To reproduce the problem, you can use the following script which isoloates the issue.

<details>
<summary>test_optional_choice.rb</summary>

```
$LOAD_PATH.unshift(File.dirname(__FILE__) + "/lib")

require 'rasn1'
require 'openssl'
require 'pp'
require 'pry'

class TerminalIdentifier < RASN1::Model
  printable_string :TerminalIdentifier, implicit: 1
end

class PrivateDomainName < RASN1::Model
  choice :PrivateDomainName, content: [
    numeric_string(:numeric),
    printable_string(:printable)
  ]
end

# https://datatracker.ietf.org/doc/html/rfc3280#section-4.2.1.7
class BuiltInStandardAttributes < RASN1::Model
  sequence :BuiltInStandardAttributes, content: [
    # wrapper(model(:country_name, CountryName), explicit: 0, class: :application, optional: true),
    # wrapper(model(:administration_domain_name, AdministrationDomainName), explicit: 1, class: :application, optional: true),
    # wrapper(model(:network_address, NetworkAddress), implicit: 0, optional: true),
    wrapper(model(:terminal_identifier, TerminalIdentifier), implicit: 1, optional: false),
    wrapper(model(:private_domain_name, PrivateDomainName), implicit: 2, optional: true),
    # wrapper(model(:organization_name, OrganizationName), implicit: 3, optional: true),
    # wrapper(model(:numeric_user_identifier, NumericUserIdentifier), implicit: 4, optional: true),
    # wrapper(model(:personal_name, PersonalName), implicit: 5, optional: true),
    # wrapper(model(:organizational_unit_names, OrganizationalUnitNames), implicit: 6, optional: true)
  ]
end

def main_literal
  der = ('3007' + '8105' + '7674313030').scan(/../).map { |x| x.hex.chr }.join

  $stderr.puts "parsing: #{der.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join}"
  RASN1.trace do
    parsed = BuiltInStandardAttributes.parse(der)
    PP.pp(parsed)
  end
end

main_literal
```
</details>

<details>
<summary>Test Results</summary>

## Before / Unpatched
```
parsing: 300781057674313030
BuiltInStandardAttributes [ 16 ] SEQUENCE (0x30), len: 7 (0x07)
  TerminalIdentifier [ CONTEXT 1 ] IMPLICIT PrintableString (0x81), len: 5 (0x05)
    0000  76 74 31 30 30                                   vt100
  PrivateDomainName CHOICE OPTIONAL
/home/smcintyre/Repositories/rasn1/lib/rasn1/types/choice.rb:88:in `parse!': CHOICE PrivateDomainName: no type matching "" (RASN1::ASN1Error)
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/tracer.rb:120:in `parse_with_tracing'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/model.rb:423:in `parse!'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/wrapper.rb:107:in `parse!'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/types/sequence.rb:84:in `block in der_to_value'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/types/sequence.rb:83:in `each'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/types/sequence.rb:83:in `der_to_value'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/tracer.rb:144:in `der_to_value_with_tracing'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/types/base.rb:234:in `parse!'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/model.rb:423:in `parse!'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/model.rb:237:in `parse'
	from test_optional_choice.rb:39:in `block in main_literal'
	from /home/smcintyre/Repositories/rasn1/lib/rasn1/tracer.rb:50:in `trace'
	from test_optional_choice.rb:38:in `main_literal'
	from test_optional_choice.rb:44:in `<main>'
```

## After / Patched 
```
ruby test_optional_choice.rb
parsing: 300781057674313030
BuiltInStandardAttributes [ 16 ] SEQUENCE (0x30), len: 7 (0x07)
  TerminalIdentifier [ CONTEXT 1 ] IMPLICIT PrintableString (0x81), len: 5 (0x05)
    0000  76 74 31 30 30                                   vt100
  PrivateDomainName CHOICE OPTIONAL
(BuiltInStandardAttributes) BuiltInStandardAttributes SEQUENCE:
  (TerminalIdentifier) TerminalIdentifier CONTEXT [1] IMPLICIT PrintableString: "vt100"
  (PrivateDomainName) PrivateDomainName CHOICE: not chosen!
```
</details>

