### PR TITLE
RASN1.parse may parse multiple elements

### DIFF
--- a/lib/rasn1/types/base.rb
+++ b/lib/rasn1/types/base.rb
@@ -95,6 +95,7 @@ module RASN1
       # Parse a DER or BER string
       # @param [String] der_or_ber string to parse
       # @param [Hash] options
+      # @return [Base]
       # @option options [Boolean] :ber if +true+, parse a BER string, else a DER one
       # @note More options are supported. See {Base#initialize}.
       def self.parse(der_or_ber, options={})


### PR DESCRIPTION
In case of an input DER string containing multiple elements without a top container one, RASN1.parse now returns an Array of all elements, instead of only the first one.

Fix #48